### PR TITLE
Fix for 'category' and 'label' directives.

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -53,7 +53,7 @@ angular.module('angulartics', [])
     }
 
     function isProperty(name) {
-      return name.substr(0, 9) === 'analytics' && ['category'].indexOf(name.substr(10)) > -1;
+      return name.substr(0, 9) === 'analytics' && ['on', 'event'].indexOf(name.substr(10)) === -1;
     }
 
     return {


### PR DESCRIPTION
The docs indiciate you can use directives like 'analytics-category' and 'analytics-label', however these were not working.

The isProperty check was filtering them out, causing them to not be added to the tracking event properties.

I'm not sure if this is what you intended, or if I am missing something.
