### PR TITLE
Update angulartics.js

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -73,7 +73,7 @@ angular.module('angulartics', [])
         });
 
         angular.element($element[0]).bind(eventType, function() {
-          if (!properties.value && ngModel && ngModel.$viewValue) {
+          if (!properties.hasOwnProperty("value")  && ngModel && ngModel.$viewValue) {
                 properties.value = ngModel.$viewValue;
             }
           $analytics.eventTrack(eventName, properties);


### PR DESCRIPTION
This allows the directive to automatically use the value of the ng-model for the "value" parameter if there is not already an "analytics-value" attribute defined.
