### PR TITLE
Wrapped tracking calls in waitForVendorApi

### DIFF
--- a/src/angulartics-mixpanel.js
+++ b/src/angulartics-mixpanel.js
@@ -14,12 +14,16 @@
  */
 angular.module('angulartics.mixpanel', ['angulartics'])
 .config(['$analyticsProvider', function ($analyticsProvider) {
-  $analyticsProvider.registerPageTrack(function (path) {
-    mixpanel.track_pageview(path);
+  angulartics.waitForVendorApi('mixpanel', 500, function (mixpanel) {
+    $analyticsProvider.registerPageTrack(function (path) {
+      mixpanel.track_pageview(path);
+    });
   });
 
-  $analyticsProvider.registerEventTrack(function (action, properties) {
-    mixpanel.track(action, properties);
+  angulartics.waitForVendorApi('mixpanel', 500, function (mixpanel) {
+    $analyticsProvider.registerEventTrack(function (action, properties) {
+      mixpanel.track(action, properties);
+    });
   });
 }]);
 })(angular);


### PR DESCRIPTION
Prevent "mixpanel is not defined" errors if angulartics loads before the mixpanel library.
