### PR TITLE
exposing $http for custom third-party integration

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -65,7 +65,7 @@ angular.module('angulartics', [])
   };
 
   return {
-    $get: function() { return api; },
+    $get: ['$http', function($http) { api.httpService = $http; return api; }],
     settings: settings,
     virtualPageviews: function (value) { this.settings.pageTracking.autoTrackVirtualPages = value; },
     firstPageview: function (value) { this.settings.pageTracking.autoTrackFirstPage = value; },


### PR DESCRIPTION
In order to write a third-party integration that is angular based (i.e. does not already use a global object to talk to a back-end), I'd like to expose the $http service to the $analyticsProvider.

When done, one can then send requests to a back-end like so:
$analyticsProvider.registerPageTrack( function ( path ) {
  this.httpService.post(
    "ng_analytics/page",
    { "path": path },
    { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }
  );
} );
$analyticsProvider.registerEventTrack( function ( action, properties ) {
  this.httpService.post(
    "ng_analytics/event",
    { "action": action, "properties": angular.toJson( properties ) },
    { headers: {'Content-Type': 'application/x-www-form-urlencoded'} }
  );
} );

p.s. I tried sending this yesterday, but I don't think the request completed; forgive me if you see this twice.
