### PR TITLE
Switch isProperty() call param from attr to name to support data- prefix on attributes.

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -118,7 +118,7 @@ angular.module('angulartics', [])
 
       var properties = {};
       angular.forEach($attrs.$attr, function(attr, name) {
-        if (isProperty(attr)) {
+        if (isProperty(name)) {
           properties[name.slice(9).toLowerCase()] = $attrs[name];
         }
       });


### PR DESCRIPTION
This is a minor change to support the "data-" prefix on attributes of the analytics-on directive.  The substring() compare to the non-normalized name would result in "data-analytics-category" or "data-analytics-label" being ignored.
