### PR TITLE
Change karma bower dir names so grunt task runs

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-	"directory": "components"
+  "directory": "components"
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,8 +8,8 @@ module.exports = function(config) {
     frameworks: ["jasmine"],
 
     files: [
-      'bower_components/angular/angular.js',
-      'bower_components/angular-mocks/angular-mocks.js',
+      'components/angular/angular.js',
+      'components/angular-mocks/angular-mocks.js',
       'src/**/*.js',
       'test/**/*.js'
     ],


### PR DESCRIPTION
I was trying to `grunt` and kept getting angular keyword not found. When `bower install` is run, the angular and angular mocks are put into `components` not `bower_components`

Also, I hope you're ok with the minor formatting changes. If not I can revert those back. Otherwise when you `cat .bowerrc` you get a weird `%` at the end of the output. Most of the files have this actually, is this what you definitely want?
