### PR TITLE
Cordova/Phonegap support added via GAPlugin

### DIFF
--- a/src/angulartics-google-analytics-cordova.js
+++ b/src/angulartics-google-analytics-cordova.js
@@ -79,7 +79,7 @@ angular.module('angulartics.google.analytics.cordova', ['angulartics'])
     });
 
     $analyticsProvider.registerEventTrack(function (action, properties) {
-      analytics.trackEvent(success, failure, action, properties.label, properties.value, properties.scope);
+      analytics.trackEvent(success, failure, properties.category, action, properties.label, properties.value);
     });
   });
 }])


### PR DESCRIPTION
This plugin provides an integration of the GAPlugin for Cordova/Phonegap: https://github.com/phonegap-build/GAPlugin
### Usage example

Before you can start using you need to install the GAPlugin for your platform. The instructions can be found on the homepage.

Then add the plugin file to your `index.html` file:

```
<script src="angulartics-google-analytics-cordova.js"></script>
```

Now add the module to your app configuration.

```
angular.module('app', ['angulartics', 'angulartics.google.analytics.cordova']);
```

Then configure the plugin via:

```
.config('googleAnalyticsCordovaProvider', function (googleAnalyticsCordovaProvider) {
  googleAnalyticsCordovaProvider.trackingId = 'XXX';
  googleAnalyticsCordovaProvider.period = 20; // default: 10 (in seconds)
  googleAnalyticsCordovaProvider.debug = true; // default: false
})
```

That's it you now have mobile google analytics running in your app. Have fun.

Feedback is welcome!
