### PR TITLE
Fix angular-mocks dep to match angular dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angulartics",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "main": "./src/angulartics.js",
   "dependencies": {
     "angular": ">= 1.0.7",


### PR DESCRIPTION
It is helpful to have these two dependencies in sync os if a project uses a newer version of angular the dev dependencies can still be installed.

This first commit add253e is the one that would be helpful to have merged.
