### PR TITLE
angulartics-kissmetrics should work even if kissmetrics hasn't loaded

### DIFF
--- a/src/angulartics-kissmetrics.js
+++ b/src/angulartics-kissmetrics.js
@@ -12,18 +12,22 @@
  * Enables analytics support for KISSmetrics (http://kissmetrics.com)
  */
 angular.module('angulartics.kissmetrics', ['angulartics'])
-.config(['$analyticsProvider', function ($analyticsProvider) {
+.config(['$analyticsProvider', '$window', function ($analyticsProvider, $window) {
 
   // KM already supports buffered invocations so we don't need
   // to wrap these inside angulartics.waitForVendorApi
 
+  // Creates the _kqm array if it doesn't exist already
+  // Useful if you want to load angulartics before kissmetrics
+  $window._kmq = _kmq || [];
+
   $analyticsProvider.registerPageTrack(function (path) {
-    _kmq.push(['record', 'Pageview', { 'Page': path }]);
+    $window._kmq.push(['record', 'Pageview', { 'Page': path }]);
   });
 
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    _kmq.push(['record', action, properties]);
+    $window._kmq.push(['record', action, properties]);
   });
-  
+
 }]);
 })(angular);


### PR DESCRIPTION
This just creates the _kmq array if it's not already created. This is useful if you want to load angulartics and angulartics.kissmetrics before your analytics/metrics code. 
