### PR TITLE
Add ‘noninteraction’ attribute for GA event tracking

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -23,9 +23,18 @@ angular.module('angulartics.google.analytics', ['angulartics'])
     if (window.ga) ga('send', 'pageview', path);
   });
 
+  /**
+   * Track Event in GA
+   * @name eventTrack
+   *
+   * @param {string} action Required 'action' (string) associated with the event
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   *
+   * @link https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#SettingUpEventTracking
+   */
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    if (window._gaq) _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value]);
-    if (window.ga) ga('send', 'event', properties.category, action, properties.label, properties.value);
+    if (window._gaq) _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
+    if (window.ga) ga('send', 'event', properties.category, action, properties.label, properties.value, properties.noninteraction);
   });
   
 }]);


### PR DESCRIPTION
Hi Luis,

Current implementation is missing an additional optional attribute that indicates non-interaction nature of the event.

Spec is here: https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#SettingUpEventTracking

Thanks,
Alex
