### PR TITLE
add plugin for Google Tag Manager

### DIFF
--- a/samples/google-tag-manager.html
+++ b/samples/google-tag-manager.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf8">
+	<title>Google Analytics sample | Angulartics</title>
+	<link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.7/angular.min.js"></script>
+	<script src="../src/angulartics.js"></script>
+	<script src="../src/angulartics-gtm.js"></script>
+
+
+</head>
+<body ng-app="sample">
+	<!-- Google Tag Manager, replace GTM-XXXXX with your container ID -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SG4H"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-XXXXX');</script>
+<!-- End Google Tag Manager -->
+
+
+<div class="navbar navbar-default">
+	<div class="navbar-header">
+		<a class="navbar-brand" href="#/">My App</a>
+	</div>
+	<div>
+		<ul class="nav navbar-nav">
+			<li><a href="#/a">Page A</a></li>
+			<li><a href="#/b">Page B</a></li>
+			<li><a href="#/c">Page C</a></li>
+		</ul>
+	</div>
+</div>
+
+<div class="container">
+	<div ng-view></div>
+	<hr>
+
+	<button analytics-on="click" analytics-event="Button 1" analytics-category="Commands" class="btn btn-default">Button 1</button>
+
+	<!-- same as analytics-on="click", because 'click' is the default -->
+	<button analytics-on analytics-event="Button 2" analytics-category="Commands" class="btn btn-primary">Button 2</button>
+
+	<!-- same as analytics-event="Button 3", because is inferred from innerText -->
+	<button analytics-on analytics-category="Commands" class="btn btn-success">Button 3</button>
+
+	<button analytics-on analytics-label="Button4 label" analytics-value="1" class="btn btn-info">Button 4</button>
+	<hr>
+
+	<p class="alert alert-success">
+		Open the console in your browser, click any of the nav options or buttons above and you'll see the data sent the the dataLayer. Configure your containter in <a href=http://www.google.com/tagmanager> Google Tag Manager</a> to send tracking calls based on these dataLayer events.
+	</p>
+</div>
+
+<script>
+	angular.module('sample', ['angulartics', 'angulartics.google.tagmanager'])
+	.config(function ($routeProvider, $analyticsProvider) {
+		$routeProvider
+			.when('/', { templateUrl: '/~danrowe/angulartics/samples/partials/root.tpl.html', controller: 'SampleCtrl' })
+	  	.when('/a', { templateUrl: '/~danrowe/angulartics/samples/partials/a.tpl.html', controller: 'SampleCtrl' })
+		  .when('/b', { templateUrl: '/~danrowe/angulartics/samples/partials/b.tpl.html', controller: 'SampleCtrl' })
+		  .when('/c', { templateUrl: '/~danrowe/angulartics/samples/partials/c.tpl.html', controller: 'SampleCtrl' })
+		  .otherwise({ redirectTo: '/' });
+	})
+	.controller('SampleCtrl', function () {});
+</script>
+</body>
+</html>

--- a/src/angulartics-gtm.js
+++ b/src/angulartics-gtm.js
@@ -1,0 +1,57 @@
+/**
+ * @license Angulartics v0.8.5
+ * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
+ * Google Tag Manager Plugin Contributed by http://github.com/danrowe49
+ * License: MIT
+ */
+
+(function(angular){
+'use strict';
+
+
+/**
+ * @ngdoc overview
+ * @name angulartics.google.analytics
+ * Enables analytics support for Google Tag Manager (http://google.com/tagmanager)
+ */
+
+angular.module('angulartics.google.tagmanager', ['angulartics'])
+.config(['$analyticsProvider', function($analyticsProvider){
+
+	/**
+	* Send content views to the dataLayer
+	*
+	* @param {string} path Required 'content name' (string) describes the content loaded
+	*/
+
+	$analyticsProvider.registerPageTrack(function(path){
+		var dataLayer = window.dataLayer = window.dataLayer || [];
+		dataLayer.push({
+			'event': 'content-view',
+			'content-name': path
+		});	
+	});
+
+	/**
+   * Send interactions to the dataLayer, i.e. for event tracking in Google Analytics
+   * @name eventTrack
+   *
+   * @param {string} action Required 'action' (string) associated with the event
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   */
+
+	$analyticsProvider.registerEventTrack(function(action, properties){
+		var dataLayer = window.dataLayer = window.dataLayer || [];
+		dataLayer.push({
+			'event': 'interaction',
+			'target': properties.category,
+			'action': action,
+			'target-properties': properties.label,
+			'value': properties.value,
+			'interaction-type': properties.noninteraction
+		});
+
+	});
+}]);
+
+})(angular);


### PR DESCRIPTION
Added a plugin for Google Tag Manager and a test page to see it in action. The plugin follows the same model as the Google Analytics plugin, but pushes event and state information to Google Tag Managers dataLayer on pageviews or events rather than calling GA directly. This allows abstraction of tracking configuration (i.e. account ID, tracking type, etc.) from the application to an easy to use web UI at http://www.google.com/tagmanager
