### PR TITLE
fix noninteraction tracking in google universal api tracking

### DIFF
--- a/dist/angulartics-ga.min.js
+++ b/dist/angulartics-ga.min.js
@@ -4,4 +4,4 @@
  * Universal Analytics update contributed by http://github.com/willmcclellan
  * License: MIT
  */
-!function(a){"use strict";a.module("angulartics.google.analytics",["angulartics"]).config(["$analyticsProvider",function(a){a.settings.trackRelativePath=!0,a.registerPageTrack(function(a){window._gaq&&_gaq.push(["_trackPageview",a]),window.ga&&ga("send","pageview",a)}),a.registerEventTrack(function(a,b){window._gaq&&_gaq.push(["_trackEvent",b.category,a,b.label,b.value,b.noninteraction]),window.ga&&ga("send","event",b.category,a,b.label,b.value,b.noninteraction)})}])}(angular);
+!function(a){"use strict";a.module("angulartics.google.analytics",["angulartics"]).config(["$analyticsProvider",function(a){a.settings.trackRelativePath=!0,a.registerPageTrack(function(a){window._gaq&&_gaq.push(["_trackPageview",a]),window.ga&&ga("send","pageview",a)}),a.registerEventTrack(function(a,b){window._gaq?_gaq.push(["_trackEvent",b.category,a,b.label,b.value,b.noninteraction]):window.ga&&(b.noninteraction?ga("send","event",b.category,a,b.label,b.value,{nonInteraction:1}):ga("send","event",b.category,a,b.label,b.value))})}])}(angular);

--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -33,10 +33,20 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
    *
    * @link https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#SettingUpEventTracking
+   *
+   * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/events
    */
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    if (window._gaq) _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
-    if (window.ga) ga('send', 'event', properties.category, action, properties.label, properties.value, properties.noninteraction);
+    if (window._gaq) {
+      _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
+    }
+    else if (window.ga) {
+      if (properties.noninteraction) {
+        ga('send', 'event', properties.category, action, properties.label, properties.value, {nonInteraction: 1});
+      } else {
+        ga('send', 'event', properties.category, action, properties.label, properties.value);
+      }
+    }
   });
   
 }]);


### PR DESCRIPTION
The google analytics universal events tracking is not sending the noninteraction properly.  
The related code currently looks like this

``` js
if (window.ga) ga('send', 'event', properties.category, action, properties.label, properties.value, properties.noninteraction);
```

According to google's docs, https://developers.google.com/analytics/devguides/collection/analyticsjs/events, it should look like

``` js
ga('send', 'event', properties.category, action, properties.label, properties.value, {nonInteraction: 1});
```

This pull request should fix that issue.  (Also uses an `if, else if` block instead of two `if` blocks.)
