### PR TITLE
mixpanel deprecated track_pageview

### DIFF
--- a/src/angulartics-mixpanel.js
+++ b/src/angulartics-mixpanel.js
@@ -16,7 +16,7 @@ angular.module('angulartics.mixpanel', ['angulartics'])
 .config(['$analyticsProvider', function ($analyticsProvider) {
   angulartics.waitForVendorApi('mixpanel', 500, function (mixpanel) {
     $analyticsProvider.registerPageTrack(function (path) {
-      mixpanel.track_pageview(path);
+      mixpanel.track( "Page Viewed", { "page": path } );
     });
   });
 


### PR DESCRIPTION
track_pageview method was used for Streams report, but Live view has replaced Streams and does not listen to the track_pageview method. Now track_pageview is deprecated and the best approach is just a regular call to the track method.
