### PR TITLE
The user should be able to disable analytics without touching JS code.

### DIFF
--- a/src/angulartics-segmentio.js
+++ b/src/angulartics-segmentio.js
@@ -14,11 +14,23 @@
 angular.module('angulartics.segment.io', ['angulartics'])
 .config(['$analyticsProvider', function ($analyticsProvider) {
   $analyticsProvider.registerPageTrack(function (path) {
-    analytics.pageview(path);
+    try {
+        analytics.pageview(path);
+    } catch (e) {
+        if (!(e instanceof ReferenceError)) {
+            throw e;
+        }
+    }
   });
 
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    analytics.track(action, properties);
+    try {
+      analytics.track(action, properties);
+    } catch (e) {
+        if (!(e instanceof ReferenceError)) {
+            throw e;
+        }
+    }
   });
 }]);
 })(angular);


### PR DESCRIPTION
Should catch ReferenceError when analytics provider api is not able to be referenced. 

Useful when disabling analytics in dev environments by just commenting out the provider html snippet and leaving angulartics code untouched.
