### PR TITLE
Fix angulartics-scroll for ie

### DIFF
--- a/src/angulartics-scroll.js
+++ b/src/angulartics-scroll.js
@@ -38,8 +38,8 @@ angular.module('angulartics.scroll', ['angulartics'])
         }
       });
 
-      $($element[0]).waypoint(function () {
-        this.dispatchEvent(new Event('scrollby'));
+      $element.waypoint(function () {
+        $element.triggerHandler('scrollby');
       }, properties);
     }
   };


### PR DESCRIPTION
Was getting `Object doesn't support this action` in all versions of IE
(including 10), this was my fix for it :)
