### PR TITLE
Fix mixpanel initialization

### DIFF
--- a/src/angulartics-mixpanel.js
+++ b/src/angulartics-mixpanel.js
@@ -14,13 +14,13 @@
  */
 angular.module('angulartics.mixpanel', ['angulartics'])
 .config(['$analyticsProvider', function ($analyticsProvider) {
-  angulartics.waitForVendorApi('mixpanel', 500, 'track', function (mixpanel) {
+  angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
     $analyticsProvider.registerPageTrack(function (path) {
       mixpanel.track( "Page Viewed", { "page": path } );
     });
   });
 
-  angulartics.waitForVendorApi('mixpanel', 500, 'track', function (mixpanel) {
+  angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
     $analyticsProvider.registerEventTrack(function (action, properties) {
       mixpanel.track(action, properties);
     });


### PR DESCRIPTION
Mixpanel API uses an intermediate object also called mixpanel before it's really initialized. This pull request contains logic to ensure waitForVendorApi returns the correct object.
