### PR TITLE
Fix #110: Specifically support ngRoute and ui-router

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,8 @@
     "jquery-waypoints": "~v2.0.3"
   },
   "devDependencies": {
-    "angular-mocks": ">= 1.0.7"
+    "angular-mocks": ">= 1.0.7",
+    "angular-route": "~1.2",
+    "angular-ui-router": "~0.2"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,8 @@ module.exports = function(config) {
 
     files: [
       'components/angular/angular.js',
+      'components/angular-route/angular-route.js',
+      'components/angular-ui-router/release/angular-ui-router.js',
       'components/angular-mocks/angular-mocks.js',
       'src/**/*.js',
       'test/**/*.js'

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -77,7 +77,7 @@ angular.module('angulartics', [])
   };
 })
 
-.run(['$rootScope', '$location', '$analytics', function ($rootScope, $location, $analytics) {
+.run(['$rootScope', '$location', '$analytics', '$injector', function ($rootScope, $location, $analytics, $injector) {
   if ($analytics.settings.pageTracking.autoTrackFirstPage) {
     if ($analytics.settings.trackRelativePath) {
         $analytics.pageTrack($location.url());
@@ -86,11 +86,19 @@ angular.module('angulartics', [])
     }
   }
   if ($analytics.settings.pageTracking.autoTrackVirtualPages) {
-    $rootScope.$on('$locationChangeSuccess', function (event, current) {
-      if (current && (current.$$route||current).redirectTo) return;
-      var url = $analytics.settings.pageTracking.basePath + $location.url();
-      $analytics.pageTrack(url);
-    });
+    if ($injector.has('$route')) {
+      $rootScope.$on('$routeChangeSuccess', function (event, current) {
+        if (current && (current.$$route||current).redirectTo) return;
+        var url = $analytics.settings.pageTracking.basePath + $location.url();
+        $analytics.pageTrack(url);
+      });
+    }
+    if ($injector.has('$state')) {
+      $rootScope.$on('$stateChangeSuccess', function (event, current) {
+        var url = $analytics.settings.pageTracking.basePath + $location.url();
+        $analytics.pageTrack(url);
+      });
+    }
   }
 }])
 

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -13,27 +13,53 @@ describe('Module: angulartics', function() {
   });
 
   describe('Provider: analytics', function() {
-    var analytics,
-      rootScope,
-      location;
-    beforeEach(inject(function(_$analytics_, _$rootScope_, _$location_) {
-      analytics = _$analytics_;
-      location = _$location_;
-      rootScope = _$rootScope_;
-
-      spyOn(analytics, 'pageTrack');
-    }));
 
     describe('initialize', function() {
-      it('should tracking pages by default', function() {
-        expect(analytics.settings.pageTracking.autoTrackVirtualPages).toBe(true);
+      it('should track pages by default', function() {
+        inject(function(_$analytics_) {
+          expect(_$analytics_.settings.pageTracking.autoTrackVirtualPages).toBe(true);
+        });
       });
     });
 
-    it('should tracking pages on location change', function() {
-      location.path('/abc');
-      rootScope.$emit('$locationChangeSuccess');
-      expect(analytics.pageTrack).toHaveBeenCalledWith('/abc');
+    describe('ngRoute support', function () {
+      var analytics,
+        rootScope,
+        location;
+      beforeEach(module('ngRoute'));
+      beforeEach(inject(function(_$analytics_, _$rootScope_, _$location_) {
+        analytics = _$analytics_;
+        location = _$location_;
+        rootScope = _$rootScope_;
+
+        spyOn(analytics, 'pageTrack');
+      }));
+
+      it('should track pages on route change', function() {
+        location.path('/abc');
+        rootScope.$emit('$routeChangeSuccess');
+        expect(analytics.pageTrack).toHaveBeenCalledWith('/abc');
+      });
+    });
+
+    describe('ui-router support', function () {
+      var analytics,
+        rootScope,
+        location;
+      beforeEach(module('ui.router'));
+      beforeEach(inject(function(_$analytics_, _$rootScope_, _$location_) {
+        analytics = _$analytics_;
+        location = _$location_;
+        rootScope = _$rootScope_;
+
+        spyOn(analytics, 'pageTrack');
+      }));
+
+      it('should track pages on route change', function() {
+        location.path('/abc');
+        rootScope.$emit('$stateChangeSuccess');
+        expect(analytics.pageTrack).toHaveBeenCalledWith('/abc');
+      });
     });
 
   });


### PR DESCRIPTION
Trying to be routing-agnostic isn't working for us
(see luisfarzati/angulartics#86 and luisfarzati/angulartics#114).

This PR intends to re-introduce specific support for the two most popular
routing modules: ngRoute and ui-router.

Tests have been updated to cover ngRoute and ui-router. I've implicitly
documented the minimum supported versions of both modules, using bower.json.

TODO:
- Update the README to explicitly document minimum supported versions of the
  routing modules.
