### PR TITLE
Fixes issue #161 by changing kissmetrics plugin to use global window object

### DIFF
--- a/dist/angulartics-kissmetrics.min.js
+++ b/dist/angulartics-kissmetrics.min.js
@@ -3,4 +3,4 @@
  * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
  * License: MIT
  */
-!function(a){"use strict";a.module("angulartics.kissmetrics",["angulartics"]).config(["$analyticsProvider","$window",function(a,b){b._kmq=_kmq||[],a.registerPageTrack(function(a){b._kmq.push(["record","Pageview",{Page:a}])}),a.registerEventTrack(function(a,c){b._kmq.push(["record",a,c])})}])}(angular);
+!function(a){"use strict";a.module("angulartics.kissmetrics",["angulartics"]).config(["$analyticsProvider",function(a){window._kmq=_kmq||[],a.registerPageTrack(function(a){window._kmq.push(["record","Pageview",{Page:a}])}),a.registerEventTrack(function(a,b){window._kmq.push(["record",a,b])})}])}(angular);

--- a/src/angulartics-kissmetrics.js
+++ b/src/angulartics-kissmetrics.js
@@ -12,21 +12,21 @@
  * Enables analytics support for KISSmetrics (http://kissmetrics.com)
  */
 angular.module('angulartics.kissmetrics', ['angulartics'])
-.config(['$analyticsProvider', '$window', function ($analyticsProvider, $window) {
+.config(['$analyticsProvider', function ($analyticsProvider) {
 
   // KM already supports buffered invocations so we don't need
   // to wrap these inside angulartics.waitForVendorApi
 
   // Creates the _kqm array if it doesn't exist already
   // Useful if you want to load angulartics before kissmetrics
-  $window._kmq = _kmq || [];
+  window._kmq = _kmq || [];
 
   $analyticsProvider.registerPageTrack(function (path) {
-    $window._kmq.push(['record', 'Pageview', { 'Page': path }]);
+    window._kmq.push(['record', 'Pageview', { 'Page': path }]);
   });
 
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    $window._kmq.push(['record', action, properties]);
+    window._kmq.push(['record', action, properties]);
   });
 
 }]);


### PR DESCRIPTION
Fixes issue #161 by changing kissmetrics plugin to use global `window` object.  This now matches the way `window` is used in all the other plugins that use it.

The build and tests pass.  I have also done a test using this plugin and it is now successfully sending data to KissMetrics.
