### PR TITLE
google analytics: do nothing when there is no category

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -37,6 +37,10 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/events
    */
   $analyticsProvider.registerEventTrack(function (action, properties) {
+
+    // do nothing if there is no category (it's required by GA)
+    if(properties.category) { return; }
+
     // GA requires that eventValue be an integer, see:
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
     // https://github.com/luisfarzati/angulartics/issues/81


### PR DESCRIPTION
I did this line because I want to send events without category e.g. to Intercom and not to GA.. because there are limited GA requests 

and without that line GA will throw an error because there is no category!
