### PR TITLE
Include state name for plugins that support it

### DIFF
--- a/src/angulartics-kissmetrics.js
+++ b/src/angulartics-kissmetrics.js
@@ -21,8 +21,8 @@ angular.module('angulartics.kissmetrics', ['angulartics'])
   // Useful if you want to load angulartics before kissmetrics
   window._kmq = _kmq || [];
 
-  $analyticsProvider.registerPageTrack(function (path) {
-    window._kmq.push(['record', 'Pageview', { 'Page': path }]);
+  $analyticsProvider.registerPageTrack(function (path, name) {
+    window._kmq.push(['record', 'Pageview', { 'Page': path, 'Name': name }]);
   });
 
   $analyticsProvider.registerEventTrack(function (action, properties) {

--- a/src/angulartics-mixpanel.js
+++ b/src/angulartics-mixpanel.js
@@ -46,8 +46,8 @@ angular.module('angulartics.mixpanel', ['angulartics'])
   });
 
   angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
-    $analyticsProvider.registerPageTrack(function (path) {
-      mixpanel.track( "Page Viewed", { "page": path } );
+    $analyticsProvider.registerPageTrack(function (path, name) {
+      mixpanel.track( "Page Viewed", { "page": path, "name": name } );
     });
   });
 

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -37,7 +37,7 @@ angular.module('angulartics', [])
     eventTracking: {},
     bufferFlushDelay: 1000 // Support only one configuration for buffer flush delay to simplify buffering
   };
-  
+
   // List of known handlers that plugins can register themselves for
   var knownHandlers = [
     'pageTrack',
@@ -61,7 +61,7 @@ angular.module('angulartics', [])
       }
     };
   };
-  
+
   // As handlers are installed by plugins, they get pushed into a list and invoked in order.
   var updateHandlers = function(handlerName, fn){
     if(!handlers[handlerName]){
@@ -99,7 +99,7 @@ angular.module('angulartics', [])
     virtualPageviews: function (value) { this.settings.pageTracking.autoTrackVirtualPages = value; },
     firstPageview: function (value) { this.settings.pageTracking.autoTrackFirstPage = value; },
     withBase: function (value) { this.settings.pageTracking.basePath = (value) ? angular.element('base').attr('href').slice(0, -1) : ''; },
-    withAutoBase: function (value) { this.settings.pageTracking.autoBasePath = value; },    
+    withAutoBase: function (value) { this.settings.pageTracking.autoBasePath = value; },
   };
 
   // General function to register plugin handlers. Flushes buffers immediately upon registration according to the specified delay.
@@ -127,15 +127,15 @@ angular.module('angulartics', [])
     };
     api[handlerName] = updateHandlers(handlerName, bufferedHandler(handlerName));
   };
-  
+
   // Set up register functions for each known handler
   angular.forEach(knownHandlers, installHandlerRegisterFunction);
   return provider;
 })
 
 .run(['$rootScope', '$location', '$window', '$analytics', '$injector', function ($rootScope, $location, $window, $analytics, $injector) {
-  
-    
+
+
   if ($analytics.settings.pageTracking.autoTrackFirstPage) {
     /* Only track the 'first page' if there are no routes or states on the page */
     var noRoutesOrStates = true;
@@ -181,7 +181,7 @@ angular.module('angulartics', [])
     if ($injector.has('$state')) {
       $rootScope.$on('$stateChangeSuccess', function (event, current) {
         var url = $analytics.settings.pageTracking.basePath + $location.url();
-        $analytics.pageTrack(url);
+        $analytics.pageTrack(url, current.name);
       });
     }
   }
@@ -222,7 +222,7 @@ angular.module('angulartics', [])
     scope: true,
     link: function ($scope, $element, $attrs) {
       var eventType = $attrs.analyticsOn || inferEventType($element[0]);
-      
+
       $scope.$analytics = {};
 
       angular.forEach($attrs.$attr, function(attr, name) {
@@ -244,7 +244,7 @@ angular.module('angulartics', [])
           }
         }
         // Allow components to pass through an expression that gets merged on to the event properties
-        // eg. analytics-properites='myComponentScope.someConfigExpression.$analyticsProperties' 
+        // eg. analytics-properites='myComponentScope.someConfigExpression.$analyticsProperties'
         if($attrs.analyticsProperties){
           angular.extend($scope.$analytics, $scope.$eval($attrs.analyticsProperties));
         }

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -87,8 +87,8 @@ describe('Module: angulartics', function() {
 
       it('should track pages on route change', function() {
         location.path('/abc');
-        rootScope.$emit('$stateChangeSuccess');
-        expect(analytics.pageTrack).toHaveBeenCalledWith('/abc');
+        rootScope.$emit('$stateChangeSuccess', {name: 'state.name'});
+        expect(analytics.pageTrack).toHaveBeenCalledWith('/abc', 'state.name');
       });
     });
 


### PR DESCRIPTION
Including the state name can be a valuable asset for tracking services which do not have the ability to filter page urls by regular expression, like Mixpanel. Providing the state name will allow users creating reports to run statistics based on state name rather than solely the url.
