### PR TITLE
Update angularitics-splunk.js dynamic _sp

### DIFF
--- a/src/angulartics-splunk.js
+++ b/src/angulartics-splunk.js
@@ -19,14 +19,16 @@
       throw "Define sp ";
     };
 
-    var _sp = window.sp || { pageview: errorFunction, track :errorFunction};
+    var _getSp = function () {
+        return window.sp || { pageview: errorFunction, track: errorFunction };
+    };
 
     $analyticsProvider.registerPageTrack(function (path) {
-      _sp.pageview(path);
+        _getSp().pageview(path);
     });
 
     $analyticsProvider.registerEventTrack(function (action, properties) {
-      _sp.track(action, properties);
+        _getSp().track(action, properties);
     });
 
   }]);


### PR DESCRIPTION
dynamically retrieving _sp by turning this into a function is necessary for anyone wanting to run setup in the module.config or not pull/compile the html of their app when running a testing framework like Karma. Since this code was being run prior to the initialization of the module as a dependency of your app, it will error with "define sp" in all consuming unit tests.
