### PR TITLE
changed _kmq declaration

### DIFF
--- a/src/angulartics-kissmetrics.js
+++ b/src/angulartics-kissmetrics.js
@@ -19,7 +19,12 @@ angular.module('angulartics.kissmetrics', ['angulartics'])
 
   // Creates the _kqm array if it doesn't exist already
   // Useful if you want to load angulartics before kissmetrics
-  window._kmq = _kmq || [];
+  
+  if (typeof(_kmq) == "undefined") {
+    window._kmq = [];
+  } else {
+    window._kmq = _kmq;
+  };
 
   $analyticsProvider.registerPageTrack(function (path) {
     window._kmq.push(['record', 'Pageview', { 'Page': path }]);


### PR DESCRIPTION
The code was breaking when running tests with Karma.  It works fine with the app tho.  But while running Karma, it wasn't finding the _kmq array at all.  Even when I tried to inject it into the tests.  I was getting the following error: 

ReferenceError: Can't find variable: _kmq
        at /usr/local/web/src/src/vendor-bower/angulartics/dist/angulartics-kissmetrics.min.js:6

By changing the way this variable is declared allowed me to successfully run and test the code.
