### PR TITLE
Add main attr to package.json to enable browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Vendor-agnostic web analytics for AngularJS applications",
   "version": "0.17.0",
   "filename": "./src/angulartics.min.js",
+  "main" : "./src/angulartics.js",
   "homepage": "http://luisfarzati.github.io/angulartics",
   "author": {
     "name": "Luis Farzati",


### PR DESCRIPTION
Solves #194 

Can include plugins as so:

``` javascript
require('angulartics');
require('angulartics/src/angulartics-ga');
```
