### PR TITLE
Add mixpanel.alias support

### DIFF
--- a/src/angulartics-mixpanel.js
+++ b/src/angulartics-mixpanel.js
@@ -20,6 +20,12 @@ angular.module('angulartics.mixpanel', ['angulartics'])
       mixpanel.identify(userId);
     });
   });
+  
+  angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
+    $analyticsProvider.registerSetAlias(function (userId) {
+      mixpanel.alias(userId);
+    });
+  });
 
   angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
     $analyticsProvider.registerSetSuperPropertiesOnce(function (properties) {


### PR DESCRIPTION
Add `mixpanel.alias` support to call event after user signs up (it should be used instead of `mixpanel.identify` to keep signup funnels).

Reference: https://mixpanel.com/help/reference/javascript
