### PR TITLE
Fix Mixpanel alias support

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -42,6 +42,7 @@ angular.module('angulartics', [])
   var knownHandlers = [
     'pageTrack',
     'eventTrack',
+    'setAlias',
     'setUsername',
     'setUserProperties',
     'setUserPropertiesOnce',


### PR DESCRIPTION
The mixpanel provider is unable to register the setAlias call because this is missing from the list of known handlers.
