### PR TITLE
New developer mode to prevent sending data

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -35,7 +35,8 @@ angular.module('angulartics', [])
       basePath: ''
     },
     eventTracking: {},
-    bufferFlushDelay: 1000 // Support only one configuration for buffer flush delay to simplify buffering
+    bufferFlushDelay: 1000, // Support only one configuration for buffer flush delay to simplify buffering
+    developerMode: false // Prevent sending data in local/development environment
   };
 
   // List of known handlers that plugins can register themselves for
@@ -101,6 +102,7 @@ angular.module('angulartics', [])
     firstPageview: function (value) { this.settings.pageTracking.autoTrackFirstPage = value; },
     withBase: function (value) { this.settings.pageTracking.basePath = (value) ? angular.element('base').attr('href').slice(0, -1) : ''; },
     withAutoBase: function (value) { this.settings.pageTracking.autoBasePath = value; },
+    developerMode: function(value) { this.settings.developerMode = value; }
   };
 
   // General function to register plugin handlers. Flushes buffers immediately upon registration according to the specified delay.
@@ -183,6 +185,13 @@ angular.module('angulartics', [])
         $analytics.pageTrack(url);
       });
     }
+  }
+  if ($analytics.settings.developerMode) {
+    angular.forEach($analytics, function(attr, name) {
+      if (typeof attr === 'function') {
+        $analytics[name] = function(){};
+      }
+    });
   }
 }])
 


### PR DESCRIPTION
Almost always when we are developing in a development or local environment, we don't want to expose this data to the analytics service. Otherwise we can misguide the real analytics.

That is why we need a `developerMode`. Setting it to `true` in the `$analyticsProvider` config will prevent from sending any data.
