### PR TITLE
Added nuspec file for additional modules

### DIFF
--- a/nuget/angular.analytics.cnzz.nuspec
+++ b/nuget/angular.analytics.cnzz.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.CNZZ</id>
+        <version>0.17.1</version>
+        <title>Angulartics for CNZZ</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>CNZZ module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>CNZZ for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics cnzz</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-cnzz.js" target="content\Scripts\angulartics-cnzz.js" />
+        <file src="..\dist\angulartics-cnzz.min.js" target="content\Scripts\angulartics-cnzz.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.debug.nuspec
+++ b/nuget/angular.analytics.debug.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Debug</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Debug</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Debug module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Debug for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics debug</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-debug.js" target="content\Scripts\angulartics-debug.js" />
+        <file src="..\dist\angulartics-debug.min.js" target="content\Scripts\angulartics-debug.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.hubspot.nuspec
+++ b/nuget/angular.analytics.hubspot.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Hubspot</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Hubspot</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Hubspot module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Hubspot for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics hubspot</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-hubspot.js" target="content\Scripts\angulartics-hubspot.js" />
+        <file src="..\dist\angulartics-hubspot.min.js" target="content\Scripts\angulartics-hubspot.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.intercom.nuspec
+++ b/nuget/angular.analytics.intercom.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Intercom</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Intercom</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Intercom module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Intercom for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics intercom</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-intercom.js" target="content\Scripts\angulartics-intercom.js" />
+        <file src="..\dist\angulartics-intercom.min.js" target="content\Scripts\angulartics-intercom.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.localytics.nuspec
+++ b/nuget/angular.analytics.localytics.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Localytics</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Localytics</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Localytics module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Localytics for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics localytics</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-localytics.js" target="content\Scripts\angulartics-localytics.js" />
+        <file src="..\dist\angulartics-localytics.min.js" target="content\Scripts\angulartics-localytics.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.loggly.nuspec
+++ b/nuget/angular.analytics.loggly.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Loggly</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Loggly</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Loggly module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Loggly for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics loggly</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-loggly.js" target="content\Scripts\angulartics-loggly.js" />
+        <file src="..\dist\angulartics-loggly.min.js" target="content\Scripts\angulartics-loggly.min.js" />
+    </files>
+</package>

--- a/nuget/angular.analytics.marketo.nuspec
+++ b/nuget/angular.analytics.marketo.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Angular.Analytics.Marketo</id>
+        <version>0.17.1</version>
+        <title>Angulartics for Marketo</title>
+        <authors>luisfarzati,ADAPTByDesign</authors>
+        <projectUrl>http://luisfarzati.github.io/angulartics/</projectUrl>
+        <iconUrl>http://luisfarzati.github.io/angulartics/images/angularjs.png</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Marketo module for Angulartics.
+See Angular.Analytics.Core for more details
+
+[NuGet packaging by ADAPTByDesign]
+</description>
+        <summary>Marketo for AngularJS applications</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>angularjs analytics marketo</tags>
+        <dependencies>
+            <dependency id="Angular.Analytics.Core" version="0.17.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\src\angulartics-marketo.js" target="content\Scripts\angulartics-marketo.js" />
+        <file src="..\dist\angulartics-marketo.min.js" target="content\Scripts\angulartics-marketo.min.js" />
+    </files>
+</package>


### PR DESCRIPTION
I have pushed v 0.17.1 to NuGet and noticed that additional modules had been created without .nuspec files.

This pull request includes the additional .nupsec files.

.nupsec files are simple to create for each new module, just need to update the module name references and file references.

This should be done for any new modules.
