### PR TITLE
GA multi-account modification

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -19,10 +19,21 @@ angular.module('angulartics.google.analytics', ['angulartics'])
   // to wrap these inside angulartics.waitForVendorApi
 
   $analyticsProvider.settings.trackRelativePath = true;
+  
+  // Set the default settings for this module
+  $analyticsProvider.settings.ga = {
+    // array of additional account names (only works for analyticsjs)
+    additionalAccountNames: undefined
+  };
 
   $analyticsProvider.registerPageTrack(function (path) {
     if (window._gaq) _gaq.push(['_trackPageview', path]);
-    if (window.ga) ga('send', 'pageview', path);
+    if (window.ga) {
+      ga('send', 'pageview', path);
+      angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+        ga(accountName +'.send', 'pageview', path);
+      });
+    }
   });
 
   /**
@@ -72,6 +83,9 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 	    }
 	  }
 	  ga('send', 'event', eventOptions);
+	  angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
+            ga(accountName +'.send', 'event', eventOptions);
+          });
     }
   });
 


### PR DESCRIPTION
Uses a `$analyticsProvider.settings.ga` object for configuration, which after initing multiple analytics accounts like this:

``` javascript
    ga('create', 'UA-XXXXXX-XX');
    ga('create', 'UA-XXXXXX-XY', 'auto', {'name': 'additionalTracker1'});
    ga('create', 'UA-XXXXXX-XZ', 'auto', {'name': 'additionalTracker2'});
```

allows to configure the additional providers on startup:

``` javascript
config(function ($analyticsProvider) {
    $analyticsProvider.settings.ga.additionalAccountNames = ['additionalTracker1', 'additionalTracker2'];
  });
```

You can also change the configuration while running the app which, while not the most elegant solution, allows sending only some events to multiple accounts by:

``` javascript
 $analyticsProvider.settings.ga.additionalAccountNames = ['additionalTracker1'];
 $analytics.eventTrack('eventName');
 $analyticsProvider.settings.ga.additionalAccountNames = [];
```
