### PR TITLE
ADD support for Cordova google-analytics-plugin

### DIFF
--- a/src/angulartics-ga-cordova-google-analytics-plugin.js
+++ b/src/angulartics-ga-cordova-google-analytics-plugin.js
@@ -1,0 +1,90 @@
+/**
+ * @license Angulartics v0.17.0
+ * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
+ * License: MIT
+ */
+(function(angular) {
+'use strict';
+
+/**
+ * @ngdoc overview
+ * @name angulartics.google.analytics
+ * Enables analytics support for Google Analytics (http://google.com/analytics)
+ * for Cordova with google-analytics-plugin (https://github.com/danwilson/google-analytics-plugin)
+ */
+angular.module('angulartics.google.analytics.cordova', ['angulartics'])
+
+.provider('googleAnalyticsCordova', function () {
+  var GoogleAnalyticsCordova = [
+  '$q', '$log', 'ready', 'debug', 'trackingId', 'period',
+  function ($q, $log, ready, debug, trackingId, period) {
+    var deferred = $q.defer();
+    var deviceReady = false;
+
+    window.addEventListener('deviceReady', function () {
+      deviceReady = true;
+      deferred.resolve();
+    });
+
+    setTimeout(function () {
+      if (!deviceReady) {
+        deferred.resolve();
+      }
+    }, 3000);
+
+    function success() {
+      if (debug) {
+        $log.info(arguments);
+      }
+    }
+
+    function failure(err) {
+      if (debug) {
+        $log.error(err);
+      }
+    }
+
+    this.init = function () {
+      return deferred.promise.then(function () {
+        if (typeof analytics != 'undefined') {
+          ready(analytics, success, failure);
+          analytics.startTrackerWithId(trackingId);
+        } else if (debug) {
+          $log.error('Google Analytics Plugin for Cordova is not available');
+        }
+      });
+    };
+  }];
+
+  return {
+    $get: ['$injector', function ($injector) {
+      return $injector.instantiate(GoogleAnalyticsCordova, {
+        ready: this._ready || angular.noop,
+        debug: this.debug,
+        trackingId: this.trackingId,
+        period: this.period
+      });
+    }],
+    ready: function (fn) {
+      this._ready = fn;
+    }
+  };
+})
+
+.config(['$analyticsProvider', 'googleAnalyticsCordovaProvider', function ($analyticsProvider, googleAnalyticsCordovaProvider) {
+  googleAnalyticsCordovaProvider.ready(function (analytics, success, failure) {
+    $analyticsProvider.registerPageTrack(function (path) {
+      analytics.trackView(path);
+    });
+
+    $analyticsProvider.registerEventTrack(function (action, properties) {
+      analytics.trackEvent(properties.category, action, properties.label, properties.value);
+    });
+  });
+}])
+
+.run(['googleAnalyticsCordova', function (googleAnalyticsCordova) {
+  googleAnalyticsCordova.init();
+}]);
+
+})(angular);


### PR DESCRIPTION
Currently only the GAPlugin for Cordova/Phonegap (https://github.com/phonegap-build/GAPlugin) is supported (#60 thanks to @mlegenhausen).

This plugin provides an integration of the google-analytics-plugin for Cordova/Phonegap: https://github.com/danwilson/google-analytics-plugin

Usage example:

Before you can start using you need to install the google-analytics-plugin for your platform. The instructions can be found on the homepage.

Then add the plugin file to your index.html file:

```
<script src="angulartics-ga-cordova-google-analytics-plugin.js"></script>
```

Now add the module to your app configuration.

```
angular.module('app', ['angulartics', 'angulartics.google.analytics.cordova']);
```

Then configure the plugin via:

```
.config('googleAnalyticsCordovaProvider', function (googleAnalyticsCordovaProvider) {
  googleAnalyticsCordovaProvider.trackingId = 'XXX';
  googleAnalyticsCordovaProvider.debug = true; // default: false
})
```

That's it you now have mobile google analytics running in your app.

Feedback is welcome!
