### PR TITLE
fix(angulartics-ga.js): Check for both ga and _gaq

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -61,6 +61,9 @@ angular.module('angulartics.google.analytics', ['angulartics'])
       properties.value = isNaN(parsed) ? 0 : parsed;
     }
 
+    if (window._gaq) {
+      _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
+    }
     if (window.ga) {
 	  var eventOptions = {
 		eventCategory: properties.category || null,
@@ -83,9 +86,6 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 	  angular.forEach($analyticsProvider.settings.ga.additionalAccountNames, function (accountName){
             ga(accountName +'.send', 'event', eventOptions);
           });
-    }
-    else if (window._gaq) {
-      _gaq.push(['_trackEvent', properties.category, action, properties.label, properties.value, properties.noninteraction]);
     }
   });
 


### PR DESCRIPTION
Right now, angulartics-ga.js checks for `window._gaq` before `window.ga` to decide what form of event tracking to use. Since, with the [new tracker script](https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs#snippet), both variables are declared on the window object, only the `_gaq` form of event tracking is used. That causes event tracking to fail.

This makes event tracking work with the new tracker script by checking for both `window.ga` and `window._gaq`.
