### PR TITLE
Stopgap for jquery-waypoints migration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "angular": ">= 1.1.5",
-    "jquery-waypoints": "~v2.0.3",
+    "waypoints": "git@github.com:imakewebthings/waypoints.git",
     "SHA-1": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
They were terrible and just deleted the entire old project and moved to a new git.

Was: https://github.com/imakewebthings/jquery-waypoints

Now: https://github.com/imakewebthings/waypoints/

Should be "waypoints": "~3.0.0" but bower.io hasn't been registered yet.
