### PR TITLE
jquery-waypoints doesn't exist

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "angular": ">= 1.1.5",
-    "jquery-waypoints": "~v2.0.3",
+    "waypoints": "~2.0.3",
     "SHA-1": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
It doesn't exist anymore and now when I `bower install angulartics` I get this:

```
~/Desktop
🍔  $ bower install angulartics
bower angulartics#*             cached git://github.com/luisfarzati/angulartics.git#0.17.1
bower angulartics#*           validate 0.17.1 against git://github.com/luisfarzati/angulartics.git#*
bower jquery-waypoints#~v2.0.3       not-cached git://github.com/imakewebthings/jquery-waypoints.git#~v2.0.3
bower jquery-waypoints#~v2.0.3          resolve git://github.com/imakewebthings/jquery-waypoints.git#~v2.0.3
bower SHA-1#*                        not-cached git://github.com/linkgod/SHA-1.git#*
bower SHA-1#*                           resolve git://github.com/linkgod/SHA-1.git#*
bower angular#>= 1.1.5                   cached git://github.com/angular/bower-angular.git#1.3.7
bower angular#>= 1.1.5                 validate 1.3.7 against git://github.com/angular/bower-angular.git#>= 1.1.5
bower SHA-1#*                          checkout master
bower SHA-1#*                          resolved git://github.com/linkgod/SHA-1.git#2151275d92
bower jquery-waypoints#~v2.0.3     ENORESTARGET No tag found that was able to satisfy ~v2.0.3

Additional error details:
No versions found in git://github.com/imakewebthings/jquery-waypoints.git
```

This resolves this issue, though the demo may need some updates to the path for the js file or something...
