### PR TITLE
New Handler: eventTrackAdditional

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angulartics",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "main": [
     "src/angulartics.js",
     "src/angulartics-clicky.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angulartics",
   "description": "Vendor-agnostic web analytics for AngularJS applications",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "filename": "./src/angulartics.min.js",
   "main": "./src/angulartics.js",
   "homepage": "http://luisfarzati.github.io/angulartics",

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -43,6 +43,7 @@ angular.module('angulartics', [])
   var knownHandlers = [
     'pageTrack',
     'eventTrack',
+    'eventTrackAdditional',
     'setAlias',
     'setUsername',
     'setUserProperties',


### PR DESCRIPTION
This new handler is to be used for send an event to additional projects/libraries/instances of a single analytics provider, as well as the initial one.

### Use Case
Currently, there is no way for a Angulartics user to be able to send events to more than one MixPanel project. This is useful when tracking analytics internally, as well as giving a client access to a separate account.

This new handler allows an additional `libraries[Array]` parameter which specifies the additional libraries you want to send any given event to.

### Example Usage
angulartics-mixpanel integration:
```
  angulartics.waitForVendorApi('mixpanel', 500, '__loaded', function (mixpanel) {
    $analyticsProvider.registerEventTrackAdditional(function (action, properties, libraries) {
      
      // Track event in main library
      mixpanel.track(action, properties);      
      
      // Loop through additional libraries, track events
      for (var i = 0; i < libraries.length; i++) {
        var library = libraries[i];
        mixpanel[library].track(action, properties);
      }
    });
  });
```
Called in app:
```
    var libraries = ['secondary'];
    $analytics.eventTrackAdditional(eventName, data, libraries);
```

This usage would send an event to Mixpanel's main project, as well as the  'secondary' project.