### PR TITLE
Added GTM Container file for easy import

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Name and case must match
     Label: **{{angulartics event label}}**
     Value: **{{angulartics event value}}**
     Non-Interaction Hit: **{{angulartics event interaction type}}**
+    More settings > Field to Set > name: **page**, value: **{{angulartics page path}}**
     Fire On: **Angulartics events**
 2. **Angulartics Pageviews**
     Product: **Google Analytics**
@@ -190,6 +191,7 @@ Name and case must match
     Label: **{{angulartics event label}}**
     Value: **{{angulartics event value}}**
     Non-Interaction Hit: **{{angulartics event interaction type}}**
+    More settings > Basic Configuration > Document Path: **{{angulartics page path}}**
     Firing Rules: **Angulartics events**
 2. **Angulartics Pageviews**
     Product: **Google Analytics**

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ See [angulartics-google-analytics](https://github.com/angulartics/angulartics-go
 Add the full tracking code from Google Tag Manager to the beginning of your body tag.
 
 #### OPTION A) Import the necessary configurations into Google Tag Manager
-Open Google Tag Manager and navigate to the Admin Tab. Select *Import Container*, then select *Merge* and *Rename conflicting tags, triggers, and variables*. Click *Choose Container File* and select *google-tag-manager-import.json* from this repository. Click *continue*, then confirm.
+Open Google Tag Manager and navigate to the Admin Tab. Select **Import Container**, then select **Merge**. From the dropdown, select **Rename conflicting tags, triggers, and variables**. Click **Choose Container File** and select **google-tag-manager-import.json** from this repository. Click **Continue**, then **Confirm**. This will add the Tags, Triggers, and Variables needed by Angulartics to your container.
 
-Navigate to the Variables tab and click *Google Analytics Tracking ID - Angulartics*. Change this value to your Google Analytics Tracking ID, otherwise known as a UA Number. This can be found next to the name of your Google Analytics Property in the Google Analytics interface. No further configurations are necessary.
+Navigate to the Variables tab, scroll beneath the Built-In Variables section, and click **Google Analytics Tracking ID - Angulartics** from the list at the bottom. Change this value to your Google Analytics Tracking ID, otherwise known as a UA Number. This can be found next to the name of your Google Analytics Property in the Google Analytics interface. No further configurations are necessary.
 
 #### OPTION B) Manually configure necessary configurations in Google Tag Manager
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Name and case must match
     Value: **{{angulartics event value}}**
     Non-Interaction Hit: **{{angulartics event interaction type}}**
     More settings > Field to Set > name: **page**, value: **{{angulartics page path}}**
+    More settings > Field to Set > name: **cookieDomain**, value: **auto**
     Fire On: **Angulartics events**
 2. **Angulartics Pageviews**
     Product: **Google Analytics**
@@ -137,6 +138,7 @@ Name and case must match
     Tracking ID: **YourGoogleAnalyticsID**
     Track Type: **Page View**
     More settings > Field to Set > name: **page**, value: **{{angulartics page path}}**
+    More settings > Field to Set > name: **cookieDomain**, value: **auto**
     Fire On: **Angulartics pageviews**
 
 ### for Google Tag Manager (old interface)

--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ See [angulartics-google-analytics](https://github.com/angulartics/angulartics-go
 Add the full tracking code from Google Tag Manager to the beginning of your body tag.
 
 #### OPTION A) Import the necessary configurations into Google Tag Manager
-Open Google Tag Manager and navigate to the Admin Tab. Select **Import Container**, then select **Merge**. From the dropdown, select **Rename conflicting tags, triggers, and variables**. Click **Choose Container File** and select **google-tag-manager-import.json** from this repository. Click **Continue**, then **Confirm**. This will add the Tags, Triggers, and Variables needed by Angulartics to your container.
+- Open Google Tag Manager and navigate to the Admin Tab
+- Select **Import Container**, then select **Merge**
+- From the dropdown, select **Rename conflicting tags, triggers, and variables**
+- Click **Choose Container File** and select **google-tag-manager-import.json** from this repository 
+- Click **Continue**, then **Confirm**
+- Navigate to the Variables tab 
+- Scroll beneath the Built-In Variables section, and click **Google Analytics Tracking ID - Angulartics** from the list at the bottom 
+- Change this value to your Google Analytics Tracking ID in the format UA-XXXXXX-YY (can be found in the Google Analytics Admin -> Property Settings menu)
+- Save the changes to the Variable
 
-Navigate to the Variables tab, scroll beneath the Built-In Variables section, and click **Google Analytics Tracking ID - Angulartics** from the list at the bottom. Change this value to your Google Analytics Tracking ID, otherwise known as a UA Number. This can be found next to the name of your Google Analytics Property in the Google Analytics interface. No further configurations are necessary.
+This will add the Tags, Triggers, and Variables needed by Angulartics to your container.
 
 #### OPTION B) Manually configure necessary configurations in Google Tag Manager
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ See [angulartics-google-analytics](https://github.com/angulartics/angulartics-go
 
 Add the full tracking code from Google Tag Manager to the beginning of your body tag.
 
+#### OPTION A) Import the necessary configurations into Google Tag Manager
+Open Google Tag Manager and navigate to the Admin Tab. Select *Import Container*, then select *Merge* and *Rename conflicting tags, triggers, and variables*. Click *Choose Container File* and select *google-tag-manager-import.json* from this repository. Click *continue*, then confirm.
+
+Navigate to the Variables tab and click *Google Analytics Tracking ID - Angulartics*. Change this value to your Google Analytics Tracking ID, otherwise known as a UA Number. This can be found next to the name of your Google Analytics Property in the Google Analytics interface. No further configurations are necessary.
+
+#### OPTION B) Manually configure necessary configurations in Google Tag Manager
+
 Setup listeners in Google Tag Manager
 
 #### 6 Variables

--- a/google-tag-manager-import.json
+++ b/google-tag-manager-import.json
@@ -1,0 +1,454 @@
+{
+    "exportFormatVersion": 1.3,
+    "containerVersion": {
+        "tag": [
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "tagId": "2",
+                "name": "Angulartics Events",
+                "type": "ua",
+                "liveOnly": false,
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "enableEcommerce",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setTrackerName",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "doubleClick",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "trackingId",
+                        "value": "{{Google Analytics Tracking ID - Angulartics}}"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "enableLinkId",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "eventAction",
+                        "value": "{{angulartics event action}}"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "eventValue",
+                        "value": "{{angulartics event value}}"
+                    },
+                    {
+                        "type": "LIST",
+                        "key": "fieldsToSet",
+                        "list": [
+                            {
+                                "type": "MAP",
+                                "map": [
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "fieldName",
+                                        "value": "page"
+                                    },
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "value",
+                                        "value": "{{angulartics page path}}"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "MAP",
+                                "map": [
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "fieldName",
+                                        "value": "cookieDomain"
+                                    },
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "value",
+                                        "value": "auto"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "useDebugVersion",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "trackType",
+                        "value": "TRACK_EVENT"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "nonInteraction",
+                        "value": "{{angulartics event interaction type}}"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "eventLabel",
+                        "value": "{{angulartics event label}}"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "eventCategory",
+                        "value": "{{angulartics event category}}"
+                    }
+                ],
+                "fingerprint": "0",
+                "firingTriggerId": [
+                    "2"
+                ],
+                "parentFolderId": "3",
+                "tagFiringOption": "ONCE_PER_EVENT"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "tagId": "1",
+                "name": "Angulartics Pageviews",
+                "type": "ua",
+                "liveOnly": false,
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "enableEcommerce",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setTrackerName",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "useHashAutoLink",
+                        "value": "false"
+                    },
+                    {
+                        "type": "LIST",
+                        "key": "fieldsToSet",
+                        "list": [
+                            {
+                                "type": "MAP",
+                                "map": [
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "fieldName",
+                                        "value": "page"
+                                    },
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "value",
+                                        "value": "{{angulartics page path}}"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "MAP",
+                                "map": [
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "fieldName",
+                                        "value": "cookieDomain"
+                                    },
+                                    {
+                                        "type": "TEMPLATE",
+                                        "key": "value",
+                                        "value": "auto"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "doubleClick",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "useDebugVersion",
+                        "value": "false"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "decorateFormsAutoLink",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "trackingId",
+                        "value": "{{Google Analytics Tracking ID - Angulartics}}"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "trackType",
+                        "value": "TRACK_PAGEVIEW"
+                    },
+                    {
+                        "type": "BOOLEAN",
+                        "key": "enableLinkId",
+                        "value": "false"
+                    }
+                ],
+                "fingerprint": "0",
+                "firingTriggerId": [
+                    "1"
+                ],
+                "parentFolderId": "3",
+                "tagFiringOption": "ONCE_PER_EVENT"
+            }
+        ],
+        "fingerprint": "0",
+        "trigger": [
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "triggerId": "2",
+                "name": "Angulartics events",
+                "type": "CUSTOM_EVENT",
+                "customEventFilter": [
+                    {
+                        "type": "EQUALS",
+                        "parameter": [
+                            {
+                                "type": "TEMPLATE",
+                                "key": "arg0",
+                                "value": "{{_event}}"
+                            },
+                            {
+                                "type": "TEMPLATE",
+                                "key": "arg1",
+                                "value": "interaction"
+                            }
+                        ]
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "triggerId": "1",
+                "name": "Angulartics pageviews",
+                "type": "CUSTOM_EVENT",
+                "customEventFilter": [
+                    {
+                        "type": "EQUALS",
+                        "parameter": [
+                            {
+                                "type": "TEMPLATE",
+                                "key": "arg0",
+                                "value": "{{_event}}"
+                            },
+                            {
+                                "type": "TEMPLATE",
+                                "key": "arg1",
+                                "value": "content-view"
+                            }
+                        ]
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            }
+        ],
+        "variable": [
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "1",
+                "name": "Google Analytics Tracking ID - Angulartics",
+                "type": "c",
+                "parameter": [
+                    {
+                        "type": "TEMPLATE",
+                        "key": "value",
+                        "value": "UA-XXXXXX-YY"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "4",
+                "name": "angulartics event action",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "action"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "3",
+                "name": "angulartics event category",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "target"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "7",
+                "name": "angulartics event interaction type",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "interaction-type"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "5",
+                "name": "angulartics event label",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "target-properties"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "6",
+                "name": "angulartics event value",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "value"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            },
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "variableId": "2",
+                "name": "angulartics page path",
+                "type": "v",
+                "parameter": [
+                    {
+                        "type": "BOOLEAN",
+                        "key": "setDefaultValue",
+                        "value": "false"
+                    },
+                    {
+                        "type": "TEMPLATE",
+                        "key": "name",
+                        "value": "content-name"
+                    },
+                    {
+                        "type": "INTEGER",
+                        "key": "dataLayerVersion",
+                        "value": "2"
+                    }
+                ],
+                "fingerprint": "0",
+                "parentFolderId": "3"
+            }
+        ],
+        "folder": [
+            {
+                "accountId": "28896164",
+                "containerId": "1554238",
+                "folderId": "3",
+                "name": "Angulartics",
+                "fingerprint": "0"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Added a GTM container file with the necessary items pre-configured to simply setting things up in Google Tag Manager. Added instructions in the README.md file on how to use the container file. 

Added configurations to both tags to a.) use the default setting for cookies, per normal installation and b.) store the correct page path in the Event as well as the Pageview, a la #340 .