### PR TITLE
Remove vendor scripts form main filed of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,19 +2,7 @@
   "name": "angulartics",
   "version": "0.20.1",
   "main": [
-    "src/angulartics.js",
-    "src/angulartics-clicky.js",
-    "src/angulartics-cnzz.js",
-    "src/angulartics-ga-cordova.js",
-    "src/angulartics-gtm.js",
-    "src/angulartics-piwik.js",
-    "src/angulartics-scroll.js",
-    "src/angulartics-splunk.js",
-    "src/angulartics-woopra.js",
-    "src/angulartics-marketo.js",
-    "src/angulartics-intercom.js",
-    "src/angulartics-inspectlet.js",
-    "src/angulartics-newrelic-insights.js"
+    "src/angulartics.js"
   ],
   "dependencies": {
     "angular": ">= 1.1.5",


### PR DESCRIPTION
As was discussed in #377 & #285 having all vendor files in 'bower.json#main' is problematic when angulartics is used in projects with *bower-install* or *grunt-wiredep*. Plus according to [bower documentation](https://github.com/bower/bower.json-spec#main), main field is supposed to contain:

> The entry-point files necessary to use your package. Only one file per filetype.

Here is quick fix for those issue.