### PR TITLE
Provide interface for injecting services into handlers

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -102,7 +102,9 @@ function $analytics() {
   }
 
   var provider = {
-    $get: function() { return api; },
+    $get: function($injector) {
+      return apiWithInjector($injector);
+    },
     api: api,
     settings: settings,
     virtualPageviews: function (value) { this.settings.pageTracking.autoTrackVirtualPages = value; },
@@ -131,6 +133,13 @@ function $analytics() {
           return match.toUpperCase();
       });
   }
+
+  //provide a method to inject services into handlers
+  var apiWithInjector = function(injector) {
+    return angular.extend(api, {
+      '$inject': injector.invoke
+    });
+  };
 
   // Adds to the provider a 'register#{handlerName}' function that manages multiple plugins and buffer flushing.
   function installHandlerRegisterFunction(handlerName){

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -60,6 +60,7 @@ function $analytics() {
   // Cache and handler properties will match values in 'knownHandlers' as the buffering functons are installed.
   var cache = {};
   var handlers = {};
+  var handlerOptions = {};
 
   // General buffering handler
   function bufferedHandler(handlerName){
@@ -72,16 +73,28 @@ function $analytics() {
   }
 
   // As handlers are installed by plugins, they get pushed into a list and invoked in order.
-  function updateHandlers(handlerName, fn){
+  function updateHandlers(handlerName, fn, options){
     if(!handlers[handlerName]){
       handlers[handlerName] = [];
     }
     handlers[handlerName].push(fn);
+    handlerOptions[fn] = options;
     return function(){
-      var handlerArgs = arguments;
-      angular.forEach(handlers[handlerName], function(handler){
-        handler.apply(this, handlerArgs);
-      }, this);
+      var handlerArgs = Array.prototype.slice.apply(arguments);
+      return this.$inject(['$q', angular.bind(this, function($q) {
+        return $q.all(handlers[handlerName].map(function(handlerFn) {
+          var options = handlerOptions[handlerFn] || {};
+          if (options.async) {
+            var deferred = $q.defer();
+            var currentArgs = angular.copy(handlerArgs);
+            currentArgs.unshift(deferred.resolve);
+            handlerFn.apply(this, currentArgs);
+            return deferred.promise;
+          } else{
+            return $q.when(handlerFn.apply(this, handlerArgs));
+          }
+        }, this));
+      })]);
     };
   }
 
@@ -118,8 +131,8 @@ function $analytics() {
   };
 
   // General function to register plugin handlers. Flushes buffers immediately upon registration according to the specified delay.
-  function register(handlerName, fn){
-    api[handlerName] = updateHandlers(handlerName, fn);
+  function register(handlerName, fn, options){
+    api[handlerName] = updateHandlers(handlerName, fn, options);
     var handlerSettings = settings[handlerName];
     var handlerDelay = (handlerSettings) ? handlerSettings.bufferFlushDelay : null;
     var delay = (handlerDelay !== null) ? handlerDelay : settings.bufferFlushDelay;
@@ -144,8 +157,8 @@ function $analytics() {
   // Adds to the provider a 'register#{handlerName}' function that manages multiple plugins and buffer flushing.
   function installHandlerRegisterFunction(handlerName){
     var registerName = 'register'+capitalize(handlerName);
-    provider[registerName] = function(fn){
-      register(handlerName, fn);
+    provider[registerName] = function(fn, options){
+      register(handlerName, fn, options);
     };
     api[handlerName] = updateHandlers(handlerName, bufferedHandler(handlerName));
   }

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -236,7 +236,7 @@ describe('Module: angulartics', function() {
       var $analytics, $analyticsProvider, eventTrackSpy, someService;
       beforeEach(function() {
         someService = {
-          makeRequest: angular.noop
+          makeRequest: jasmine.createSpy()
         };
         module(function(_$analyticsProvider_, $provide) {
           $analyticsProvider = _$analyticsProvider_;
@@ -248,15 +248,13 @@ describe('Module: angulartics', function() {
         });
       });
       it('should provide a way to access services within tracking', function() {
-        spyOn(someService, 'makeRequest');
-
         $analyticsProvider.registerEventTrack(function(action, properties) {
           this.$inject(function(someService) {
             someService.makeRequest('toBeAwesome');
           });
         });
         $analytics.eventTrack('foo');
-        expect(someService.makeRequest.calls.length).toEqual(1);
+        expect(someService.makeRequest).toHaveBeenCalledWith('toBeAwesome');
       });
     });
 

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -231,6 +231,38 @@ describe('Module: angulartics', function() {
   });
 
   describe('$analytics', function() {
+
+    describe('registering hooks', function() {
+      var $analytics, $analyticsProvider, eventTrackSpy, someService;
+      beforeEach(function() {
+        someService = {
+          makeRequest: angular.noop
+        };
+        module(function(_$analyticsProvider_, $provide) {
+          $analyticsProvider = _$analyticsProvider_;
+          $provide.value('someService', someService);
+        });
+
+        inject(function(_$analytics_) {
+          $analytics = _$analytics_;
+        });
+      });
+      it('should provide a way to access services within tracking', function() {
+        spyOn(someService, 'makeRequest');
+
+        $analyticsProvider.registerEventTrack(function(action, properties) {
+          this.$inject(function(someService) {
+            someService.makeRequest('toBeAwesome');
+          });
+        });
+        $analytics.eventTrack('foo');
+        expect(someService.makeRequest.calls.length).toEqual(1);
+      });
+
+
+
+    });
+
     describe('buffering', function() {
       var $analytics, $analyticsProvider, eventTrackSpy;
       beforeEach(function() {

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -258,9 +258,42 @@ describe('Module: angulartics', function() {
         $analytics.eventTrack('foo');
         expect(someService.makeRequest.calls.length).toEqual(1);
       });
+    });
+
+    describe('promise-based completion', function() {
+      var $rootScope, $analyticsProvider, $analytics;
 
 
+      beforeEach(module(function(_$analyticsProvider_, $provide) {
+          $analyticsProvider = _$analyticsProvider_;
+        }));
 
+      beforeEach(inject(function(_$rootScope_, _$analytics_) {
+        $rootScope = _$rootScope_;
+        $analytics = _$analytics_;
+      }));
+
+      it('waits until all handlers that have callbacks return', function() {
+        var calledBack = jasmine.createSpy();
+        var someService = {}, anotherService = {};
+        anotherService.makeRequest = jasmine.createSpy();
+        someService.makeRequest = function(event, callback) {
+          callback(event);
+        };
+
+        $analyticsProvider.registerEventTrack(function(cb, action, properties) {
+          someService.makeRequest('meow', cb);
+        }, {async: true});
+
+        $analyticsProvider.registerEventTrack(function(action, properties) {
+          anotherService.makeRequest(action);
+        });
+
+        $analytics.eventTrack('foo').then(calledBack);
+        $rootScope.$digest();
+        expect(anotherService.makeRequest).toHaveBeenCalledWith('foo');
+        expect(calledBack).toHaveBeenCalledWith(jasmine.any(Array));
+      });
     });
 
     describe('buffering', function() {


### PR DESCRIPTION
There are a variety of analytics interfaces which are packaged as angular services. 

These often are preferable to using libraries declared directly on `window` because they take advantage of service like `$http` and promises. 

These services are currently unavailable within registering the event tracking because this occurs in the config stage where services are still unavailable.

This patch provides a way to access angular dependency injection within event handlers.