### PR TITLE
Add setting to exclude specific routes from pageview tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ If you want to keep pageview tracking for its traditional meaning (whole page vi
 	module.config(function ($analyticsProvider) {
 		$analyticsProvider.virtualPageviews(false);
 
+### Disabling pageview tracking for specific routes
+
+If you want to disable pageview tracking for specific routes, you can define a list of excluded routes (using strings or regular expressions):
+
+    module.config(function ($analyticsProvider) {
+    		$analyticsProvider.excludeRoutes(['/abc','/def']);
+
+Urls and routes that contain any of the strings or match any of the regular expressions will not trigger the pageview tracking.
+
 ### Programmatic tracking
 
 Use the `$analytics` service to emit pageview and event tracking:
@@ -365,7 +374,6 @@ You can assign user-related properties which will be sent along each page or eve
 Like `$analytics.pageTrack()` and `$analytics.eventTrack()`, the effect depends on the analytics provider (i.e. `$analytics.register*()`). Not all of them implement those methods.
 
 The Google Analytics module lets you call `$analytics.setUsername(username)` or set up `$analyticsProvider.settings.ga.userId = 'username'`.
-
 
 ### Developer mode
 


### PR DESCRIPTION
At the moment all routes are being tracked as pageview. In some cases, it can be necessary to exclude some of the routes from sending pageview tracking, for example if the route itself contains sensitive information that should not be sent out to third-party system.

I implemented that change locally but seeing that others showed interest about this recently (see https://github.com/angulartics/angulartics/issues/395) I thought it might be worth considering for inclusion in an upcoming version of Angulartics.

The proposed changes are:
- new excludedRoutes setting in the pageTracking settings, containing a list of strings or regular expressions that should prevent the pageview event from being triggered
- new excludeRoutes() provider configuration option (which writes to settings.pageTracking.excludedRoutes)
- when attempting to trigger a pageview event, the url is checked against the list (does it match any RegExp, or does it contain any of the strings) to verify if it should be excluded from tracking

I have also added tests to validate the new configuration options and to ensure routes are correctly excluded when matching any of the excluded routes.

Finally, I have updated the README with instructions on how to use the new setting.

(I haven't pushed changes to the /dist directory, this PR only contains source changes)