### PR TITLE
Add register user properties to Hubspot plugin

### DIFF
--- a/src/angulartics-hubspot.js
+++ b/src/angulartics-hubspot.js
@@ -34,5 +34,21 @@
 
         }
       });
+      
+      /**
+      * Add user identify to Hubspot tracking calls
+      * @name identify
+      *
+      * @param {object} properties
+      *
+      * @link http://developers.hubspot.com/docs/methods/enterprise_events/javascript_api
+      */
+
+      $analyticsProvider.registerSetUserProperties(function (properties) {
+        if (window._hsq) {
+          _hsq.push(["identify", properties]);
+        }
+      });
+
     }]);
 })(angular);


### PR DESCRIPTION
Hubspot has the ability to track users, adding a identify push call when we set the user properties