### PR TITLE
Fix broken CNZZ plugin

### DIFF
--- a/src/angulartics-cnzz.js
+++ b/src/angulartics-cnzz.js
@@ -8,7 +8,7 @@
    */
   angular.module('angulartics.cnzz', ['angulartics'])
     .config(['$analyticsProvider', function ($analyticsProvider) {
-      window._czc = _czc || [];
+      window._czc = window._czc || [];
       _czc.push(['_setAutoPageview', false]);
 
       $analyticsProvider.registerPageTrack(function (path) {


### PR DESCRIPTION
If window._czc is not declared, ```window._czc = _czc || []``` will cause a syntax error.