### PR TITLE
Add support for UI Router 1.0 which will use transition hooks

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -235,12 +235,26 @@ function $analyticsRun($rootScope, $window, $analytics, $injector) {
           pageTrack(url, $location);
         });
       }
-      if ($injector.has('$state')) {
+      if ($injector.has('$state') && !$injector.has('$transitions')) {
         noRoutesOrStates = false;
         $rootScope.$on('$stateChangeSuccess', function (event, current) {
           var url = $analytics.settings.pageTracking.basePath + $location.url();
           pageTrack(url, $location);
         });
+      }
+      if ($injector.has('$state') && $injector.has('$transitions')) {
+        noRoutesOrStates = false;
+        $injector.invoke(['$transitions', function($transitions) {
+          $transitions.onSuccess({}, function($transition$) {
+            var transitionOptions = $transition$.options();
+
+            // only track for transitions that would have triggered $stateChangeSuccess
+            if (transitionOptions.notify) {
+              var url = $analytics.settings.pageTracking.basePath + $location.url();
+              pageTrack(url, $location);
+            }
+          });
+        }]);
       }
       if (noRoutesOrStates) {
         $rootScope.$on('$locationChangeSuccess', function (event, current) {


### PR DESCRIPTION
PR for issue #454.

For tests, I've mocked the $transitions dependency instead of writing it as an integration, since UI Router 1.0 isn't released to bower yet. Let me know your thoughts on how to test against the pre-release if mocks isn't what you want.

Cheers