### PR TITLE
track exceptions via $exceptionHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Naming and case must match.
 
 Name and case must match
 
-1. **Angulartics events**  
+1. **Angulartics events**
     Condition: **{{event}} equals interaction**
 2. **Angulartics pageviews**
     Condition: **{{event}} equals content-view**
@@ -341,6 +341,14 @@ You can assign user-related properties which will be sent along each page or eve
 Like `$analytics.pageTrack()` and `$analytics.eventTrack()`, the effect depends on the analytics provider (i.e. `$analytics.register*()`). Not all of them implement those methods.
 
 The Google Analytics module lets you call `$analytics.setUsername(username)` or set up `$analyticsProvider.settings.ga.userId = 'username'`.
+
+### Exception tracking
+
+You can enable automatic exception tracking which decorates angular's `$exceptionHandler` and reports the exception to the analytics provider:
+
+    $analyticsProvider.trackExceptions(true)
+
+Currently only the Google Analytics provider supports tracking exceptions, and it does so by reporting it as an event.
 
 ### Developer mode
 

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -42,6 +42,7 @@ function $analytics() {
     },
     eventTracking: {},
     bufferFlushDelay: 1000, // Support only one configuration for buffer flush delay to simplify buffering
+    trackExceptions: false,
     developerMode: false // Prevent sending data in local/development environment
   };
 
@@ -128,6 +129,7 @@ function $analytics() {
       this.settings.pageTracking.basePath = (value) ? angular.element(document).find('base').attr('href') : '';
     },
     withAutoBase: function (value) { this.settings.pageTracking.autoBasePath = value; },
+    trackExceptions: function (value) { this.settings.trackExceptions = value; },
     developerMode: function(value) { this.settings.developerMode = value; }
   };
 
@@ -318,8 +320,12 @@ function analyticsOn($analytics) {
 function exceptionTrack($provide) {
   $provide.decorator('$exceptionHandler', ['$delegate', '$injector', function ($delegate, $injector) {
     function (error, cause) {
-      $injector.get('$analytics').exceptionTrack(error, cause);
-      return $delegate(error, cause);
+      var result = $delegate(error, cause);
+      var $analytics = $injector.get('$analytics');
+      if ($analytics.settings.trackExceptions) {
+        $analytics.exceptionTrack(error, cause);
+      }
+      return result;
     }
   }]);
 }

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -27,7 +27,8 @@ angulartics.waitForVendorApi = function (objectName, delay, containsField, regis
 angular.module('angulartics', [])
 .provider('$analytics', $analytics)
 .run(['$rootScope', '$window', '$analytics', '$injector', $analyticsRun])
-.directive('analyticsOn', ['$analytics', analyticsOn]);
+.directive('analyticsOn', ['$analytics', analyticsOn])
+.config(['$provide', exceptionTrack]);
 
 function $analytics() {
   var settings = {
@@ -312,6 +313,15 @@ function analyticsOn($analytics) {
       });
     }
   };
+}
+
+function exceptionTrack($provide) {
+  $provide.decorator('$exceptionHandler', ['$delegate', '$injector', function ($delegate, $injector) {
+    function (error, cause) {
+      $injector.get('$analytics').exceptionTrack(error, cause);
+      return $delegate(error, cause);
+    }
+  }]);
 }
 
 function isCommand(element) {


### PR DESCRIPTION
I can't find a documentation on how exceptionTrack is used, but I figured instead of writing one angulartics should track it itself (instead of the app). This also ensures a standard for all modules to use on which parameters are given to `$analytics.exceptionTrack()` (the [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) object itself).

I couldn't find any module that registers to this event, except for GA. Following the standard created here, I also made a pull request there angulartics/angulartics-google-analytics#48 which should be merged before this one is.