### PR TITLE
Add ignore key to Bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,16 @@
     "angular-route": "~1.2",
     "angular-ui-router": "~0.2"
   },
+  "ignore": [
+    ".gitignore",
+    "test",
+    "samples",
+    "LICENSE",
+    "*.md",
+    "Gruntfile.js",
+    "karma.conf.js",
+    "package.json"
+  ],
   "resolutions": {
     "angular": ">= 1.1.5"
   }


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#ignore

To get rid of this warning:
```
bower invalid-meta  angulartics is missing "ignore" entry in bower.json
```

And to make bower package more compact.