### PR TITLE
Add handler for incrementing property value

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -55,6 +55,7 @@ function $analytics() {
     'setUserPropertiesOnce',
     'setSuperProperties',
     'setSuperPropertiesOnce',
+    'incrementProperty',
     'userTimings'
   ];
   // Cache and handler properties will match values in 'knownHandlers' as the buffering functons are installed.

--- a/test/angularticsSpec.js
+++ b/test/angularticsSpec.js
@@ -257,6 +257,7 @@ describe('Module: angulartics', function() {
         'setUserPropertiesOnce',
         'setSuperProperties',
         'setSuperPropertiesOnce',
+        'incrementProperty',
         'userTimings'
       ];
       var capitalize = function(input) {


### PR DESCRIPTION
Submitting this change to add a handler for being able to increment the value of a property being tracked for a user. I have found this to be a common use-case and wanted to include it in your library. This stemmed from the use of Mixpanel's increment function: https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.people.increment