### PR TITLE
Do not register plugin handlers in developer mode

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -136,6 +136,10 @@ function $analytics() {
 
   // General function to register plugin handlers. Flushes buffers immediately upon registration according to the specified delay.
   function register(handlerName, fn, options){
+    // Do not add a handler if developerMode is true
+    if (settings.developerMode) {
+        return;
+    }
     api[handlerName] = updateHandlers(handlerName, fn, options);
     var handlerSettings = settings[handlerName];
     var handlerDelay = (handlerSettings) ? handlerSettings.bufferFlushDelay : null;


### PR DESCRIPTION
When `developerMode` is set to `true`, the angulartics library correctly clears all handlers during configuration. However some libraries (such as [Mixpanel](https://github.com/angulartics/angulartics-mixpanel)), register their handlers after loading a library. This results in events being sent even when `developerMode` is on.

To fix this, this change ignores any handler registration calls when `developerMode` is on. There may be a better place to put the check, but I'm not familiar with the library and this seemed to work.

Thanks!