### PR TITLE
Adapt to danwilson/google-analytics-plugin name change

### DIFF
--- a/src/angulartics-ga-cordova-google-analytics-plugin.js
+++ b/src/angulartics-ga-cordova-google-analytics-plugin.js
@@ -46,9 +46,10 @@ angular.module('angulartics.google.analytics.cordova', ['angulartics'])
 
     this.init = function () {
       return deferred.promise.then(function () {
-        if (typeof analytics != 'undefined') {
-          ready(analytics, success, failure);
-          analytics.startTrackerWithId(trackingId);
+        var gaAnalytics = ga || analytics;
+        if (typeof gaAnalytics != 'undefined') {
+          ready(gaAnalytics, success, failure);
+          gaAnalytics.startTrackerWithId(trackingId);
         } else if (debug) {
           $log.error('Google Analytics Plugin for Cordova is not available');
         }


### PR DESCRIPTION
the cordova plugin [danwilson/google-analytics-plugin](https://github.com/danwilson/google-analytics-plugin/pull/87) will change the name from `window.analytics` to `window.ga` for its 1.0.0 release.

this should be safe for users pre-1.0.0 and 1.0.0+.