### PR TITLE
Remove inline injector annotations from onSuccess hook

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -264,7 +264,7 @@ function $analyticsRun($rootScope, $window, $analytics, $injector) {
       if ($injector.has('$state') && $injector.has('$transitions')) {
         noRoutesOrStates = false;
         $injector.invoke(['$transitions', function($transitions) {
-          $transitions.onSuccess({}, ['$transition$', function($transition$) {
+          $transitions.onSuccess({}, function($transition$) {
             var transitionOptions = $transition$.options();
 
             // only track for transitions that would have triggered $stateChangeSuccess
@@ -272,7 +272,7 @@ function $analyticsRun($rootScope, $window, $analytics, $injector) {
               var url = $analytics.settings.pageTracking.basePath + $location.url();
               pageTrack(url, $location);
             }
-          }]);
+          });
         }]);
       }
       if (noRoutesOrStates) {


### PR DESCRIPTION
To deal with this change in angular-ui-router: https://github.com/angular-ui/ui-router/commit/ca45957901d53a77f69074d15ea87baf1b78a48c

https://github.com/angulartics/angulartics/issues/454#issuecomment-248485459