### PR TITLE
Adds better configurability to tracking events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ When working on a global product there are many countries who by default require
     // $analytics.setOptOut(boolean Optout);
     // To opt out
     $analytics.setOptOut(true);
-    
+
     // To opt in
     $analytics.setOptOut(false);
 
     // To get opt out state
-    $analytics.getOptOut(); // Returns true or false 
+    $analytics.getOptOut(); // Returns true or false
 
 
 ### Disabling virtual pageview tracking
@@ -280,6 +280,20 @@ If you want to disable pageview tracking for specific routes, you can define a l
     		$analyticsProvider.excludeRoutes(['/abc','/def']);
 
 Urls and routes that contain any of the strings or match any of the regular expressions will not trigger the pageview tracking.
+
+### Disabling tracking on $routeChangeSuccess
+
+If you want to disable pageview tracking for the $routeChangeSuccess event, set trackRoutes to false:
+
+    module.config(function ($analyticsProvider) {
+      $analyticsProvider.trackRoutes(true);
+
+### Disabling tracking on $stateChangeSuccess
+
+If you want to disable pageview tracking for the $stateChangeSuccess event, set trackStates to false:
+
+    module.config(function ($analyticsProvider) {
+      $analyticsProvider.trackStates(true);
 
 ### Programmatic tracking
 

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -144,8 +144,8 @@ function $analytics() {
     api: api,
     settings: settings,
     virtualPageviews: function (value) { this.settings.pageTracking.autoTrackVirtualPages = value; },
-    states: function (value) { this.settings.pageTracking.trackStates = value; },
-    routes: function (value) { this.settings.pageTracking.trackRoutes = value; },
+    trackStates: function (value) { this.settings.pageTracking.trackStates = value; },
+    trackRoutes: function (value) { this.settings.pageTracking.trackRoutes = value; },
     excludeRoutes: function(routes) { this.settings.pageTracking.excludedRoutes = routes; },
     firstPageview: function (value) { this.settings.pageTracking.autoTrackFirstPage = value; },
     withBase: function (value) {


### PR DESCRIPTION
Tracking on $routeChangeSuccess and $stateChangeSuccess can now be deactivated.

This PR should resolve #432 and also introduce compatibility with the angular 1.5 component router.

Right now the angular component router in 1.5 utilizes both, the $routeChangeSuccess on when the route has been resolved, and the $stateChangeSuccess on when the views controller is successfully activated. So for compatibility with the 1.5 component router, we would either disable tracking on the $routeChangeSuccess or the $stateChangeSuccess event to prevent double tracking. Which one of them should be disabled in such a case depends on the projects structure and some architectural decisions.