### PR TITLE
fix(angulartics-heap) Fail gracefully when Heap not loaded.

### DIFF
--- a/dist/angulartics-heap.min.js
+++ b/dist/angulartics-heap.min.js
@@ -9,4 +9,7 @@
  * @name angulartics.heap
  * Enables analytics support for Heap (https://heapanalytics.com/)
  */
-a.module("angulartics.heap",["angulartics"]).config(["$analyticsProvider",function(a){a.settings.trackRelativePath=!0,a.registerEventTrack(function(a,b){heap.track(a,b)}),a.registerSetUsername(function(a,b){b?heap.identify(b):heap.identify({handle:a})}),a.registerSetUserProperties(function(a){heap.setEventProperties(a)})}])}(angular);
+a.module("angulartics.heap",["angulartics"]).config(["$analyticsProvider",function(a){a.settings.trackRelativePath=!0,a.registerEventTrack(function(a,c){b("track",a,c)}),a.registerSetUsername(function(a,c){c?b("identify",c):b("identify",{handle:a})}),a.registerSetUserProperties(function(a){b("setEventProperties",a)});var b=function(){
+// Dispatch command to Heap library, and fail gracefully if it isn't loaded
+//  heap.command(arg1, arg2) becomes: dispatchToHeap('command', arg1, arg2)
+return function(){var a=arguments[0],b=Array.prototype.splice.call(arguments,1);window.heap&&window.heap[a].apply(this,b)}}()}])}(angular);

--- a/src/angulartics-heap.js
+++ b/src/angulartics-heap.js
@@ -18,21 +18,34 @@ angular.module('angulartics.heap', ['angulartics'])
   $analyticsProvider.settings.trackRelativePath = true;
 
   $analyticsProvider.registerEventTrack(function (action, properties) {
-    heap.track(action, properties);
+    dispatchToHeap('track', action, properties);
   });
 
   $analyticsProvider.registerSetUsername(function (username, properties) {
     if(properties) {
-      heap.identify(properties);
+      dispatchToHeap('identify', properties);
     }
     else {
-      heap.identify({handle: username});
+      dispatchToHeap('identify', {handle: username});
     }
   });
 
   $analyticsProvider.registerSetUserProperties(function (properties) {
-    heap.setEventProperties(properties);
+    dispatchToHeap('setEventProperties', properties);
   });
+
+  var dispatchToHeap = (function () {
+    // Dispatch command to Heap library, and fail gracefully if it isn't loaded
+    //  heap.command(arg1, arg2) becomes: dispatchToHeap('command', arg1, arg2)
+    return function() {
+      var command = arguments[0];
+      var args = Array.prototype.splice.call(arguments, 1);
+
+      if (window.heap) {
+        window.heap[command].apply(this, args);
+      }
+    };
+  })();
 
 }]);
 })(angular);


### PR DESCRIPTION
In a project I'm using Heap Analytics for, we load the Heap snippet conditionally, and as is, this plugin was erroring when Heap was not loaded.

This change brings this plugin in line with many other Angulartics plugins that check for the existence of their respective library before calling it.