### PR TITLE
Avoid "ReferenceError: ga is not defined" exception

### DIFF
--- a/src/angulartics-ga-cordova-google-analytics-plugin.js
+++ b/src/angulartics-ga-cordova-google-analytics-plugin.js
@@ -46,7 +46,7 @@ angular.module('angulartics.google.analytics.cordova', ['angulartics'])
 
     this.init = function () {
       return deferred.promise.then(function () {
-        var gaAnalytics = ga || analytics;
+        var gaAnalytics = window.ga || window.analytics;
         if (typeof gaAnalytics != 'undefined') {
           ready(gaAnalytics, success, failure);
           gaAnalytics.startTrackerWithId(trackingId);


### PR DESCRIPTION
No need to throw a fatal exception here.