### PR TITLE
Use jQuery's `on` instead of deprecated `bind`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angulartics",
   "description": "Vendor-agnostic web analytics for AngularJS applications",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "filename": "./src/angulartics.min.js",
   "main": "./src/index.js",
   "homepage": "http://angulartics.github.io/",

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -402,7 +402,7 @@ function analyticsOn($analytics) {
         }
       });
 
-      angular.element($element[0]).bind(eventType, function ($event) {
+      angular.element($element[0]).on(eventType, function ($event) {
         var eventName = $attrs.analyticsEvent || inferEventName($element[0]);
         trackingData.eventType = $event.type;
 


### PR DESCRIPTION
jQuery's `bind` method has been deprecated in favour of `on`, and for the usage here they behave identically, so this change switches to use `on` which will avoid breaking in the slim version of jQuery (which has dropped `bind` already) and the eventual future versions of jQuery and/or `angular.element` that drop it.