### PR TITLE
Fix broken Angular in samples

### DIFF
--- a/samples/heap.html
+++ b/samples/heap.html
@@ -4,7 +4,8 @@
 	<meta charset="utf8">
 	<title>Heap sample | Angulartics</title>
 	<link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
 	<script src="../src/angulartics.js"></script>
 	<script src="../src/angulartics-heap.js"></script>
     <script type="text/javascript">window.heap=window.heap||[],heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+t+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};heap.load("<heap_id>");</script>
@@ -56,7 +57,7 @@
 </div>
 
 <script>
-	angular.module('sample', ['angulartics', 'angulartics.heap'])
+	angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.heap'])
 	.config(function ($routeProvider, $analyticsProvider) {
 		$routeProvider
 			.when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/inspectlet.html
+++ b/samples/inspectlet.html
@@ -4,7 +4,8 @@
 	<meta charset="utf8">
 	<title>Inspectlet sample | Angulartics</title>
 	<link rel="stylesheet" href="http://bootswatch.com/cosmo/bootstrap.min.css">
-	<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
 	<script src="../src/angulartics.js"></script>
 	<script src="../src/angulartics-inspectlet.js"></script>
 	
@@ -58,7 +59,7 @@
 	</div>
 
 	<script>
-		angular.module('sample', ['angulartics', 'angulartics.inspectlet'])
+		angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.inspectlet'])
 		.config(function ($routeProvider, $analyticsProvider) {
 			$routeProvider
 			.when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/loggly.html
+++ b/samples/loggly.html
@@ -5,7 +5,8 @@
   <title>Loggly sample | Angulartics</title>
   <link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
   <script src="../src/angulartics.js"></script>
   <script src="../src/angulartics-loggly.js"></script>
   <script type="text/javascript" src="loggly.tracker.js" async> </script> 
@@ -51,7 +52,7 @@
 </div>
 
 <script>
-  angular.module('sample', ['angulartics', 'angulartics.loggly'])
+  angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.loggly'])
   .config(function ($routeProvider, $analyticsProvider) {
     $routeProvider
       .when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/newrelic-insights.html
+++ b/samples/newrelic-insights.html
@@ -5,7 +5,8 @@
   <title>New Relic Insights sample | Angulartics</title>
   <link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
 
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
   <script src="../src/angulartics.js"></script>
   <script src="../src/angulartics-newrelic-insights.js"></script>
   <script type="text/javascript">
@@ -50,7 +51,7 @@ window.NREUM||(NREUM={}),__nr_require=function(t,e,n){function r(n){if(!e[n]){va
 </div>
 
 <script>
-  angular.module('sample', ['angulartics', 'angulartics.newrelic.insights'])
+  angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.newrelic.insights'])
   .config(function ($routeProvider, $analyticsProvider) {
     $routeProvider
       .when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/piwik.html
+++ b/samples/piwik.html
@@ -4,7 +4,8 @@
 	<meta charset="utf8">
 	<title>Piwik sample | Angulartics</title>
 	<link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
 	<script src="../src/angulartics.js"></script>
 	<script src="../src/angulartics-piwik.js"></script>
 	<!-- Piwik -->
@@ -62,7 +63,7 @@
 </div>
 
 <script>
-	angular.module('sample', ['angulartics', 'angulartics.piwik'])
+	angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.piwik'])
 	.config(function ($routeProvider, $analyticsProvider) {
 		$routeProvider
 			.when('/',  { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/splunk.html
+++ b/samples/splunk.html
@@ -5,7 +5,8 @@
 	<title>Splunk sample | Angulartics</title>
 	<link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
 
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
 	<script src="../src/angulartics.js"></script>
 	<script src="../src/angulartics-splunk.js"></script>
 	<script type="text/javascript">
@@ -51,7 +52,7 @@
 </div>
 
 <script>
-	angular.module('sample', ['angulartics', 'angulartics.splunk'])
+	angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.splunk'])
 	.config(function ($routeProvider, $analyticsProvider) {
 		$routeProvider
 			.when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })

--- a/samples/woopra.html
+++ b/samples/woopra.html
@@ -5,7 +5,8 @@
 	<title>Segment.io sample | Angulartics</title>
 	<link rel="stylesheet" href="//bootswatch.com/cosmo/bootstrap.min.css">
 
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.11/angular-route.js"></script>
 	<script src="../src/angulartics.js"></script>
 	<script src="../src/angulartics-woopra.js"></script>
 	<script type="text/javascript">
@@ -53,7 +54,7 @@
 </div>
 
 <script>
-	angular.module('sample', ['angulartics', 'angulartics.woopra'])
+	angular.module('sample', ['ngRoute', 'angulartics', 'angulartics.woopra'])
 	.config(function ($routeProvider, $analyticsProvider) {
 		$routeProvider
 			.when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })


### PR DESCRIPTION
Samples used Angular 1.1.5 but this version is too old to work with current Angulartics

Browser logs show for example:
```
angular.element(...).on is not a function
link@angulartics.js:405:7
```