### PR TITLE
Correctly trigger autoTrackFirstPage

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -294,10 +294,7 @@ function $analyticsRun($rootScope, $window, $analytics, $injector) {
          }
       } else if ($injector.has('$state')) {
         var $state = $injector.get('$state');
-        for (var state in $state.get()) {
-          noRoutesOrStates = false;
-          break;
-        }
+        if ($state.get().length > 1) noRoutesOrStates = false;
       }
       if (noRoutesOrStates) {
         if ($analytics.settings.pageTracking.autoBasePath) {


### PR DESCRIPTION
`autoTrackFirstPage` was checking whether the site has any states declared with ui-router by running `$state.get()` and checking its length. However, ui-router will _always_ create an abstract parent state with URL `'^'`. This caused `autoTrackFirstPage` to never fire because `$state.get()` always had an item.

To correctly fire `autoTrackFirstPage` it should run when only one state
is declared. Closes #563.

I'm fairly confident in this fix, I checked the return value of `$state.get()` for a few versions. However, someone more familiar with the topic should really chime in on this.