### PR TITLE
URL segment filtering

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "angular-mocks": ">= 1.1.5",
-    "angular-route": "~1.2",
+    "angular-route": ">= 1.1.5",
     "angular-ui-router": "~0.2"
   },
   "ignore": [


### PR DESCRIPTION
For security reasons we need to scrub URL segments that may contain sensitive values.  I followed the same process as the query key blacklist, obviously substituting URL segments for query keys.

One potential hiccup is that the URL can be relative or absolute.  According to [docs](https://code.angularjs.org/1.2.32/docs/api/ng/service/$location) `$location.url()`, the primary function used to grab the URL, includes a leading `/`.  This results in the first segment being empty or base path and is skipped by the code.  There are tests for both cases.

I've included a commit that alters the version of `angular-route` to match `angular`.  It is my understanding that these libraries should be the same version and tests were failing without this fix.  I can easily remove this patch if not desired.

Thanks for your consideration.