### PR TITLE
Change SHA-1 version due to the latest version did an issue with angularjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "dependencies": {
     "angular": ">= 1.1.5",
-    "SHA-1": "*"
+    "SHA-1": "0.1.1"
   },
   "devDependencies": {
     "angular-mocks": ">= 1.1.5",


### PR DESCRIPTION
After the last update from SHA-1 from 0.1.1 to 1.0.0 it uses 'export' keyword which not allowed in angularjs, so I made the version of SHA-1 fixed to 0.1.1